### PR TITLE
Fix a linting error & update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"exec"
 	],
 	"dependencies": {
-		"execa": "^0.7.0",
+		"execa": "^0.10.0",
 		"p-finally": "^1.0.0",
 		"pify": "^3.0.0",
 		"rimraf": "^2.5.4",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
 	},
 	"devDependencies": {
 		"ava": "*",
+		"file-type": "^7.6.0",
 		"gifsicle": "^3.0.4",
-		"is-gif": "^1.0.0",
 		"path-exists": "^3.0.0",
 		"xo": "*"
 	}

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import gifsicle from 'gifsicle';
-import isGif from 'is-gif';
+import fileType from 'file-type';
 import pathExists from 'path-exists';
 import pify from 'pify';
 import test from 'ava';
@@ -22,7 +22,7 @@ test('return a optimized buffer', async t => {
 	});
 
 	t.true(data.length < buf.length);
-	t.true(isGif(data));
+	t.is(fileType(data).ext, 'gif');
 });
 
 test('remove temporary files', async t => {

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ import isGif from 'is-gif';
 import pathExists from 'path-exists';
 import pify from 'pify';
 import test from 'ava';
-import m from './';
+import m from '.';
 
 test('set temporary directories', t => {
 	const {input, output} = m;


### PR DESCRIPTION
`is-gif` 2.0 is simply a wrapper around `file-type`, I instead opted to just using it directly.